### PR TITLE
Added `webpack-dev-server`

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,19 @@ Eventually you'll want to understand the environment though, but of course that 
 1. Install [Node.js](https://nodejs.org) if you haven't already.
 2. Open your command line and navigate to the project. (['Shift + Right Click' in explorer -> 'Open Command Line/Powershell here'](http://i.imgur.com/6FJcydX.png))
 3. Do `npm install` to fetch [npm](https://www.npmjs.com/) dependencies.
-4. Do `npm run dev` to build the existing `src`.
-5. Open `index.html` in the `dist` folder.
-6. You should (hopefully) get a page in your browser with some text on it and stuff.
-7. Start building your React app!
+
+### Running locally
+
+1. Do `npm run dev` to start a local development server.
+2. On your browser, navigate to `localhost:8080`.
+3. You should (hopefully) get a page in your browser with some text on it and stuff.
+4. Start building your React app! (When you make changes, it will automatically be reflected on your browser.)
+
+### Building for production
+
+1. When you've finished building your React app, do run `npm run build` to create a production-ready build of your React app. (**TODO:** possibly compress the compiled CSS/JS for the production build?)
+2. Put the generated files (should be inside the `dist/` folder) on your web server.
+3. You're done!
 
 ## Commands
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "main": "index.js",
   "scripts": {
-    "dev": "webpack -d --watch",
+    "dev": "webpack-dev-server --content-base dist/",
     "build": "webpack -p"
   },
   "dependencies": {
@@ -30,5 +30,8 @@
     "react-dom": "^15.5.4",
     "sass-loader": "^6.0.5",
     "webpack": "^2.6.1"
+  },
+  "devDependencies": {
+    "webpack-dev-server": "^2.4.5"
   }
 }


### PR DESCRIPTION
`webpack-dev-server` allows you to run your compiled React app on a local development server (ie. on `localhost:8080`), which will be automatically reloaded whenever changes are made.

This means that the `npm run dev` command will solely be used to start a local dev server, and `npm run build` will solely be used to create a production-ready build of our React app (**TODO:** possibly compress the compiled CSS/JS for the production build?)

**Note:** I'm still not running npm v5, so I can't really update the npm lockfile.